### PR TITLE
More work on summary

### DIFF
--- a/Shared/Characters/Raids/Details/RaidDetails.swift
+++ b/Shared/Characters/Raids/Details/RaidDetails.swift
@@ -86,11 +86,11 @@ struct RaidDetails: View {
                 ToolbarItem(placement: .principal) {
                     Text("\(raid.raidName)")
                 }
-                ToolbarItemGroup(placement: .primaryAction) {
-                    Button("Print Data") {
-                        print(raid)
-                    }.padding()
-                }
+//                ToolbarItemGroup(placement: .primaryAction) {
+//                    Button("Print Data") {
+//                        print(raid)
+//                    }.padding()
+//                }
             }
             
         }

--- a/Shared/GameDataInfo/GameDataLoader.swift
+++ b/Shared/GameDataInfo/GameDataLoader.swift
@@ -35,9 +35,6 @@ struct GameDataLoader: View {
             }
             
         }
-        .onAppear {
-            gameData.loadGameData(authorizedBy: authorization)
-        }
     }
 }
 

--- a/Shared/NavigationView/MainScreen.swift
+++ b/Shared/NavigationView/MainScreen.swift
@@ -47,6 +47,7 @@ struct MainScreen: View {
                                 )
                             )
                         }
+//                        .onDelete(perform: delete)
                     } else {
                         CharacterLoadingListItem()
                             .listRowBackground(
@@ -63,7 +64,7 @@ struct MainScreen: View {
                 ) {
                     NavigationLink(
                         destination:
-                            Text("Hello World"),
+                            SummaryMain(),
                         tag: "summary",
                         selection: $selection) {
                         SummaryListItem()
@@ -94,7 +95,7 @@ struct MainScreen: View {
                     }
                     .listRowBackground(
                         DefaultListItemBackground(
-                            color: Color.green,
+                            color: Color.orange,
                             selected: selection == "raid-settings"
                         )
                     )
@@ -129,10 +130,18 @@ struct MainScreen: View {
                 }
                     
             }
+            SummaryMain()
         }
         .navigationViewStyle(DoubleColumnNavigationViewStyle())
+        .onAppear {
+            gameData.loadGameData(authorizedBy: authorization)
+        }
         
     }
+    
+//    func delete(at offsets: IndexSet ) {
+//        print(offsets)
+//    }
 }
 
 struct MainScreen_Previews: PreviewProvider {

--- a/Shared/Summary/SummaryMain.swift
+++ b/Shared/Summary/SummaryMain.swift
@@ -1,0 +1,37 @@
+//
+//  SummaryMain.swift
+//  WoWWidget (iOS)
+//
+//  Created by Mikolaj Lukasik on 05/10/2020.
+//
+
+import SwiftUI
+
+struct SummaryMain: View {
+    @EnvironmentObject var farmOrder: FarmCollectionsOrder
+    @EnvironmentObject var authorization: Authentication
+    @EnvironmentObject var gameData: GameData
+    var body: some View {
+        if gameData.loadingAllowed {
+            
+        } else {
+            ScrollView{
+                ProgressView()
+                    .progressViewStyle(CircularProgressViewStyle())
+                Text("Loading data…")
+                Text("\(gameData.characters.count) characters")
+                Text("\(gameData.expansions.count) expansions")
+                Text("\(gameData.raids.count) raids")
+                Text("\(gameData.raidEncounters.count) raid encounters")
+                Text("\(gameData.characterRaidEncounters.count) additional character data")
+                
+            }
+        }
+    }
+}
+
+struct SummaryMain_Previews: PreviewProvider {
+    static var previews: some View {
+        SummaryMain()
+    }
+}

--- a/WoWWidget.xcodeproj/project.pbxproj
+++ b/WoWWidget.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		C8BB333825030E07003E105F /* RaidOptionsListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BB333625030E07003E105F /* RaidOptionsListItem.swift */; };
 		C8BB333A25031D08003E105F /* FarmCollectionsOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BB333925031D08003E105F /* FarmCollectionsOrder.swift */; };
 		C8BB333B25031D08003E105F /* FarmCollectionsOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BB333925031D08003E105F /* FarmCollectionsOrder.swift */; };
+		C8D58901252BB715008FAA3F /* SummaryMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D58900252BB715008FAA3F /* SummaryMain.swift */; };
 		C8E4D71924F2A5A500EDAC85 /* InstanceTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E4D71824F2A5A500EDAC85 /* InstanceTile.swift */; };
 		C8E4D71A24F2A5A500EDAC85 /* InstanceTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E4D71824F2A5A500EDAC85 /* InstanceTile.swift */; };
 		C8E4D71C24F2BDD200EDAC85 /* InstanceMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E4D71B24F2BDD200EDAC85 /* InstanceMedia.swift */; };
@@ -204,6 +205,7 @@
 		C8BB333325030DC8003E105F /* RaidOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaidOptions.swift; sourceTree = "<group>"; };
 		C8BB333625030E07003E105F /* RaidOptionsListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaidOptionsListItem.swift; sourceTree = "<group>"; };
 		C8BB333925031D08003E105F /* FarmCollectionsOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FarmCollectionsOrder.swift; sourceTree = "<group>"; };
+		C8D58900252BB715008FAA3F /* SummaryMain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryMain.swift; sourceTree = "<group>"; };
 		C8E4D71824F2A5A500EDAC85 /* InstanceTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstanceTile.swift; sourceTree = "<group>"; };
 		C8E4D71B24F2BDD200EDAC85 /* InstanceMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstanceMedia.swift; sourceTree = "<group>"; };
 		C8E6D7E1252A8613005F0918 /* SummaryListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryListItem.swift; sourceTree = "<group>"; };
@@ -281,6 +283,7 @@
 				C8B14256251D0656004F982B /* textures.xcassets */,
 				C849961C25153834007D1762 /* Characters */,
 				C8FFADAA2525533900465313 /* StaticStrings.swift */,
+				C8D588FF252BB6F8008FAA3F /* Summary */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -431,6 +434,14 @@
 				C818B1DB2521060D00ED06B7 /* NotableItemsInRaid.swift */,
 			);
 			path = Details;
+			sourceTree = "<group>";
+		};
+		C8D588FF252BB6F8008FAA3F /* Summary */ = {
+			isa = PBXGroup;
+			children = (
+				C8D58900252BB715008FAA3F /* SummaryMain.swift */,
+			);
+			path = Summary;
 			sourceTree = "<group>";
 		};
 		C8E4D71E24F31DFA00EDAC85 /* GameDataInfo */ = {
@@ -689,6 +700,7 @@
 				C88EEA9D24E9E2B800155CBC /* JSONCoreDataManager.swift in Sources */,
 				C806FA522501A7B2006DEF78 /* CharacterRaidTile.swift in Sources */,
 				C887120F24E4A01200C0A0ED /* LoginScreen.swift in Sources */,
+				C8D58901252BB715008FAA3F /* SummaryMain.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
*changed the data loading start point from the navigation bar button to navigation view, as the button is not displayed immediately on some devices which go immediately to detail view (iPad in vertical mode)
*created SummaryMain for summarized farming data
* commented the debug button in raid details, as it was causing the back button to disappear