### PR TITLE
Continued work on raid summary per character

### DIFF
--- a/Shared/Characters/Raids/Details/NotableItemsInRaid.swift
+++ b/Shared/Characters/Raids/Details/NotableItemsInRaid.swift
@@ -49,7 +49,8 @@ struct NotableItemsInRaid: View {
                 mount.id == wrapper.item.id
             }) {
                 mountsInEncounter.append(wrapper.item)
-            } else if gameData.petItemsList.contains(where: { (pet) -> Bool in
+            }
+            if gameData.petItemsList.contains(where: { (pet) -> Bool in
                 pet.id == wrapper.item.id
             }) {
                 petsInEncounter.append(wrapper.item)

--- a/Shared/Characters/Raids/RaidDataFilledAndSorted.swift
+++ b/Shared/Characters/Raids/RaidDataFilledAndSorted.swift
@@ -23,7 +23,7 @@ struct RaidDataFilledAndSorted {
     private let comfortFarm: [CombinedRaidWithEncounters]
     private let completed: [CombinedRaidWithEncounters]
     private let ignored: [CombinedRaidWithEncounters]
-    public let raidsCollection: [NamedRaidCollection]
+    public var raidsCollection: [NamedRaidCollection]
     
     init(basedOn characterEncounters: [CombinedRaidWithEncounters], for character: CharacterInProfile, farmingOrder: FarmCollectionsOrder) {
         let helper = RaidDataHelper()
@@ -145,5 +145,14 @@ struct RaidDataFilledAndSorted {
         )
         
         raidsCollection = raidsToSave.sorted()
+    }
+    
+    mutating func prepareForSummary() {
+        self.raidsCollection.removeAll { (namedCollection) -> Bool in
+            namedCollection.name == "Ignored"
+        }
+        self.raidsCollection.removeAll { (namedCollection) -> Bool in
+            namedCollection.name == "Completed"
+        }
     }
 }

--- a/Shared/Characters/Raids/RaidDataHelper.swift
+++ b/Shared/Characters/Raids/RaidDataHelper.swift
@@ -347,22 +347,25 @@ struct RaidDataHelper {
     }
     
     public func isLegacyModeCleared(for raidMode: RaidEncountersForCharacter) -> Bool {
-        let lastReset = dateOfLastWeeklyReset()
-        guard let encounter = raidMode.progress.encounters.last,
-              let timestamp = encounter.lastKillTimestamp else { return false }
-        return timestamp > lastReset
-        
+        guard let encounter = raidMode.progress.encounters.last else { return false }
+        return isEncounterCleared(encounter)
     }
     
     public func isModeCleared(for raidMode: RaidEncountersForCharacter) -> Bool {
-        let lastReset = dateOfLastWeeklyReset()
-        
         for encounter in raidMode.progress.encounters {
-            guard let killTimestamp = encounter.lastKillTimestamp,
-                  killTimestamp > lastReset else {
+            guard isEncounterCleared(encounter) else {
                 return false
             }
-            
+        }
+        return true
+    }
+    
+    public func isEncounterCleared(_ encounter: EncounterPerBossPerCharacter) -> Bool {
+        let lastReset = dateOfLastWeeklyReset()
+        
+        guard let killTimestamp = encounter.lastKillTimestamp,
+              killTimestamp > lastReset else {
+            return false
         }
         return true
     }

--- a/Shared/Characters/Raids/RaidFarmingCollection.swift
+++ b/Shared/Characters/Raids/RaidFarmingCollection.swift
@@ -191,7 +191,6 @@ struct RaidFarmingCollection: View {
                     }
                 }
                 
-                
                 combineCharacterEncountersWithData()
             }
 

--- a/Shared/GameDataInfo/DataLoadingInfo.swift
+++ b/Shared/GameDataInfo/DataLoadingInfo.swift
@@ -1,0 +1,25 @@
+//
+//  DataLoadingInfo.swift
+//  WoWWidget (iOS)
+//
+//  Created by Mikolaj Lukasik on 06/10/2020.
+//
+
+import SwiftUI
+
+struct DataLoadingInfo: View {
+    @EnvironmentObject var gameData: GameData
+    var body: some View {
+        ScrollView{
+            ProgressView()
+                .progressViewStyle(CircularProgressViewStyle())
+            Text("Loading data…")
+            Text("\(gameData.characters.count) characters")
+            Text("\(gameData.expansions.count) expansions")
+            Text("\(gameData.raids.count) raids")
+            Text("\(gameData.raidEncounters.count) raid encounters")
+            Text("\(gameData.characterRaidEncounters.count) additional character data")
+            
+        }
+    }
+}

--- a/Shared/NavigationView/MainScreen.swift
+++ b/Shared/NavigationView/MainScreen.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct MainScreen: View {
+    @Environment (\.colorScheme) var colorScheme: ColorScheme
     @EnvironmentObject var gameData: GameData
     @EnvironmentObject var authorization: Authentication
     @State var selection: String? = ""
@@ -120,7 +121,7 @@ struct MainScreen: View {
                 ToolbarItem(placement: .principal){
                     Text("WoWWidget")
                         .fontWeight(.black)
-                        .shadow(color: .white, radius: 1, x: 0, y: 0)
+                        .shadow(color: .white, radius: colorScheme == .dark ? 0 : 1, x: 0, y: 0)
                 }
                 
                 ToolbarItem(placement: .primaryAction) {

--- a/Shared/Summary/SingleCharacterSummary.swift
+++ b/Shared/Summary/SingleCharacterSummary.swift
@@ -1,0 +1,126 @@
+//
+//  SingleCharacterSummary.swift
+//  WoWWidget (iOS)
+//
+//  Created by Mikolaj Lukasik on 06/10/2020.
+//
+
+import SwiftUI
+
+struct SingleCharacterSummary: View {
+    @EnvironmentObject var farmOrder: FarmCollectionsOrder
+    @EnvironmentObject var gameData: GameData
+    
+    let characterEncounters: CharacterRaidEncounters
+    
+    @State var notableRaids: [CombinedRaidWithEncounters] = []
+    
+    @State var message: String = "Loading…"
+    
+    var body: some View {
+        
+        if notableRaids.count > 0 {
+            Text(characterEncounters.character.name)
+            VStack{
+                ForEach(notableRaids, id: \.raidId) { raid in
+                    Text(raid.raidName)
+                }
+            }.padding()
+        } else {
+            Text(message)
+                .padding()
+                .onAppear(perform: {
+                    DispatchQueue.main.async {
+                        combineCharacterEncountersWithData()
+                    }
+                })
+        }
+        
+    }
+    
+    func getCharacterBasedOn(encounters: CharacterRaidEncounters) -> CharacterInProfile {
+        let character = gameData.characters.first { (GDCharacter) -> Bool in
+            GDCharacter.name == encounters.character.name && GDCharacter.realm.name == encounters.character.realm.name
+        }
+        
+        
+        return character!
+    }
+    
+    func combineCharacterEncountersWithData() {
+        guard gameData.raids.count > 0 else { return }
+        let raidDataManipulator = RaidDataHelper()
+        let character = getCharacterBasedOn(encounters: characterEncounters)
+        let combinedRaidInfo = raidDataManipulator.createFullRaidData(using: characterEncounters, with: gameData, filter: .highest, filterForFaction: character.faction)
+        
+        var allDataCombined = RaidDataFilledAndSorted(basedOn: combinedRaidInfo, for: character, farmingOrder: farmOrder)
+        
+        allDataCombined.prepareForSummary()
+        
+        var allRaids: [CombinedRaidWithEncounters] = []
+        
+        allDataCombined.raidsCollection.forEach { (raidCollection) in
+            allRaids.append(contentsOf: raidCollection.raids)
+        }
+        
+        if allRaids.count == 0 {
+            message = "No notable raids with loot left for \(character.name)"
+            return
+        }
+        
+        var raidsWorthFarming: [CombinedRaidWithEncounters] = []
+        
+        for raid in allRaids {
+            if raidsWorthFarming.count < 4 {
+                if isRaidWorthFarming(raid) {
+                    raidsWorthFarming.append(raid)
+                }
+            } else {
+                break
+            }
+        }
+        withAnimation {
+            notableRaids.append(contentsOf: raidsWorthFarming)
+        }
+    }
+    
+    func isRaidWorthFarming(_ raid: CombinedRaidWithEncounters) -> Bool {
+        let raidDataManipulator = RaidDataHelper()
+        
+        var worthFarming: Bool = false
+        
+        for encounter in raid.records.first!.progress.encounters {
+            let loot = gameData.raidEncounters.first { (journalEncounter) -> Bool in
+                journalEncounter.id == encounter.encounter.id
+            }
+            
+            guard let currentEncounterWithLoot = loot else { return false }
+            
+            for wrapper in currentEncounterWithLoot.items {
+                if gameData.mountItemsList.contains(where: { (mount) -> Bool in
+                    mount.id == wrapper.item.id
+                }) {
+                    worthFarming = true
+                }
+                if gameData.petItemsList.contains(where: { (pet) -> Bool in
+                    pet.id == wrapper.item.id
+                }) {
+                    worthFarming = true
+                }
+            }
+            
+            if worthFarming && raidDataManipulator.isEncounterCleared(encounter) {
+                worthFarming = false
+            }
+            
+            if worthFarming {
+                return true
+            }
+            
+        }
+        
+        return false
+    }
+    
+    
+}

--- a/Shared/Summary/SummaryMain.swift
+++ b/Shared/Summary/SummaryMain.swift
@@ -8,30 +8,18 @@
 import SwiftUI
 
 struct SummaryMain: View {
-    @EnvironmentObject var farmOrder: FarmCollectionsOrder
-    @EnvironmentObject var authorization: Authentication
     @EnvironmentObject var gameData: GameData
     var body: some View {
         if gameData.loadingAllowed {
-            
-        } else {
-            ScrollView{
-                ProgressView()
-                    .progressViewStyle(CircularProgressViewStyle())
-                Text("Loading data…")
-                Text("\(gameData.characters.count) characters")
-                Text("\(gameData.expansions.count) expansions")
-                Text("\(gameData.raids.count) raids")
-                Text("\(gameData.raidEncounters.count) raid encounters")
-                Text("\(gameData.characterRaidEncounters.count) additional character data")
-                
+            ScrollView {
+                ForEach(gameData.characterRaidEncounters, id: \.character.id) { GDCharacterEncounters in
+                    SingleCharacterSummary(characterEncounters: GDCharacterEncounters)
+                }
             }
+        } else {
+            DataLoadingInfo()
         }
     }
 }
 
-struct SummaryMain_Previews: PreviewProvider {
-    static var previews: some View {
-        SummaryMain()
-    }
-}
+

--- a/WoWWidget.xcodeproj/project.pbxproj
+++ b/WoWWidget.xcodeproj/project.pbxproj
@@ -104,6 +104,8 @@
 		C8BB333A25031D08003E105F /* FarmCollectionsOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BB333925031D08003E105F /* FarmCollectionsOrder.swift */; };
 		C8BB333B25031D08003E105F /* FarmCollectionsOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BB333925031D08003E105F /* FarmCollectionsOrder.swift */; };
 		C8D58901252BB715008FAA3F /* SummaryMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D58900252BB715008FAA3F /* SummaryMain.swift */; };
+		C8D5890B252CF656008FAA3F /* DataLoadingInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D5890A252CF656008FAA3F /* DataLoadingInfo.swift */; };
+		C8D58911252D286A008FAA3F /* SingleCharacterSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D58910252D286A008FAA3F /* SingleCharacterSummary.swift */; };
 		C8E4D71924F2A5A500EDAC85 /* InstanceTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E4D71824F2A5A500EDAC85 /* InstanceTile.swift */; };
 		C8E4D71A24F2A5A500EDAC85 /* InstanceTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E4D71824F2A5A500EDAC85 /* InstanceTile.swift */; };
 		C8E4D71C24F2BDD200EDAC85 /* InstanceMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E4D71B24F2BDD200EDAC85 /* InstanceMedia.swift */; };
@@ -206,6 +208,8 @@
 		C8BB333625030E07003E105F /* RaidOptionsListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaidOptionsListItem.swift; sourceTree = "<group>"; };
 		C8BB333925031D08003E105F /* FarmCollectionsOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FarmCollectionsOrder.swift; sourceTree = "<group>"; };
 		C8D58900252BB715008FAA3F /* SummaryMain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryMain.swift; sourceTree = "<group>"; };
+		C8D5890A252CF656008FAA3F /* DataLoadingInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataLoadingInfo.swift; sourceTree = "<group>"; };
+		C8D58910252D286A008FAA3F /* SingleCharacterSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleCharacterSummary.swift; sourceTree = "<group>"; };
 		C8E4D71824F2A5A500EDAC85 /* InstanceTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstanceTile.swift; sourceTree = "<group>"; };
 		C8E4D71B24F2BDD200EDAC85 /* InstanceMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstanceMedia.swift; sourceTree = "<group>"; };
 		C8E6D7E1252A8613005F0918 /* SummaryListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryListItem.swift; sourceTree = "<group>"; };
@@ -440,6 +444,7 @@
 			isa = PBXGroup;
 			children = (
 				C8D58900252BB715008FAA3F /* SummaryMain.swift */,
+				C8D58910252D286A008FAA3F /* SingleCharacterSummary.swift */,
 			);
 			path = Summary;
 			sourceTree = "<group>";
@@ -452,6 +457,7 @@
 				C8E4D71824F2A5A500EDAC85 /* InstanceTile.swift */,
 				C874D5CD24F2926A0006B210 /* ExpansionGameDataPreview.swift */,
 				C8F942DC24EDB65C00B6222C /* DataHealthScreen.swift */,
+				C8D5890A252CF656008FAA3F /* DataLoadingInfo.swift */,
 			);
 			path = GameDataInfo;
 			sourceTree = "<group>";
@@ -676,8 +682,10 @@
 				C811E78B24E01B1F0050F6CD /* AuthCheckingScreen.swift in Sources */,
 				C8B1426C251D61CB004F982B /* DefaultListItemBackground.swift in Sources */,
 				C8F942D924EDAC1600B6222C /* LogOutListItem.swift in Sources */,
+				C8D5890B252CF656008FAA3F /* DataLoadingInfo.swift in Sources */,
 				C8B14265251D5653004F982B /* NavListSectionHeader.swift in Sources */,
 				C8E4D71924F2A5A500EDAC85 /* InstanceTile.swift in Sources */,
+				C8D58911252D286A008FAA3F /* SingleCharacterSummary.swift in Sources */,
 				C8F942E124EDC02900B6222C /* ExpansionJournal.swift in Sources */,
 				C811E78924E01B1F0050F6CD /* WoWWidgetApp.swift in Sources */,
 				C831CC3A24E7296A00C25F67 /* CharacterListItem.swift in Sources */,


### PR DESCRIPTION
fixed raid details to include mounts and pets, not mounts or pets
new function for removing ignored and completed raids to prepare object for summary
refactor of functions checking if raid is cleared
new function to check if single encounter is cleared
summary loading moved to separate file
fixed some async bugs
caught a lot of selfs in closures
changed the shadow on app title to only appear in light mode
selecting 4 raid per character with mounts and pets to find